### PR TITLE
Add an API & make surveys polymorphic

### DIFF
--- a/app/controllers/rapidfire/attempts_controller.rb
+++ b/app/controllers/rapidfire/attempts_controller.rb
@@ -13,10 +13,14 @@ module Rapidfire
     def create
       @attempt_builder = AttemptBuilder.new(attempt_params)
 
-      if @attempt_builder.save
-        redirect_to after_answer_path_for
-      else
-        render :new
+      respond_to do |format|
+        if @attempt_builder.save
+          format.html { redirect_to after_answer_path_for }
+          format.json { render json: @attempt_builder, status: 201 }
+        else
+          format.html { render :new }
+          format.json { render json: @attempt_builder.errors, status: 422 }
+        end
       end
     end
 
@@ -27,10 +31,14 @@ module Rapidfire
     def update
       @attempt_builder = AttemptBuilder.new(attempt_params)
 
-      if @attempt_builder.save
-        redirect_to surveys_path
-      else
-        render :edit
+      respond_to do |format|
+        if @attempt_builder.save
+          format.html { redirect_to surveys_path }
+          format.json { render json: @attempt_builder, status: 201 }
+        else
+          format.html { render :edit }
+          format.json { render json: @attempt_builder, status: 422 }
+        end
       end
     end
 

--- a/app/controllers/rapidfire/attempts_controller.rb
+++ b/app/controllers/rapidfire/attempts_controller.rb
@@ -1,5 +1,6 @@
 module Rapidfire
   class AttemptsController < Rapidfire::ApplicationController
+    protect_from_forgery with: :null_session
     if Rails::VERSION::MAJOR ==  5
       before_action :find_survey!
     else
@@ -16,10 +17,10 @@ module Rapidfire
       respond_to do |format|
         if @attempt_builder.save
           format.html { redirect_to after_answer_path_for }
-          format.json { render json: @attempt_builder, status: 201 }
+          format.json { render json: @attempt_builder.to_model, include: :answers, status: 201 }
         else
           format.html { render :new }
-          format.json { render json: @attempt_builder.errors, status: 422 }
+          format.json { render json: @attempt_builder.to_model.errors.messages, status: 422 }
         end
       end
     end
@@ -37,7 +38,7 @@ module Rapidfire
           format.json { render json: @attempt_builder, status: 201 }
         else
           format.html { render :edit }
-          format.json { render json: @attempt_builder, status: 422 }
+          format.json { render json: @attempt_builder.errors, status: 422 }
         end
       end
     end

--- a/app/controllers/rapidfire/questions_controller.rb
+++ b/app/controllers/rapidfire/questions_controller.rb
@@ -12,6 +12,11 @@ module Rapidfire
 
     def index
       @questions = @survey.questions
+
+      respond_to do |format|
+        format.html { render :index }
+        format.json { render json: @questions }
+      end
     end
 
     def new
@@ -37,6 +42,7 @@ module Rapidfire
       @question.destroy
       respond_to do |format|
         format.html { redirect_to index_location }
+        format.json { head 204 }
         format.js
       end
     end
@@ -47,14 +53,14 @@ module Rapidfire
       @question_form = QuestionForm.new(params)
       @question_form.save
 
-      if @question_form.errors.empty?
-        respond_to do |format|
+      respond_to do |format|
+        if @question_form.errors.empty?
           format.html { redirect_to index_location }
+          format.json { render json: @question_form, status: 201 }
           format.js
-        end
-      else
-        respond_to do |format|
+        else
           format.html { render on_error_key.to_sym }
+          format.json { render json: @question_form.errors, status: 422 }
           format.js
         end
       end

--- a/app/controllers/rapidfire/surveys_controller.rb
+++ b/app/controllers/rapidfire/surveys_controller.rb
@@ -20,14 +20,14 @@ module Rapidfire
 
     def create
       @survey = Survey.new(survey_params)
-      if @survey.save
-        respond_to do |format|
+      respond_to do |format|
+        if @survey.save
           format.html { redirect_to surveys_path }
+          format.json { render json: @survey, status: 201 }
           format.js
-        end
-      else
-        respond_to do |format|
+        else
           format.html { render :new }
+          format.json { render json: @survey.errors, status: 422 }
           format.js
         end
       end
@@ -39,6 +39,7 @@ module Rapidfire
 
       respond_to do |format|
         format.html { redirect_to surveys_path }
+        format.json { head 204 }
         format.js
       end
     end

--- a/app/models/rapidfire/survey.rb
+++ b/app/models/rapidfire/survey.rb
@@ -1,6 +1,7 @@
 module Rapidfire
   class Survey < ActiveRecord::Base
     has_many  :questions
+    belongs_to :surveyable, polymorphic: true
     validates :name, :presence => true
 
     if Rails::VERSION::MAJOR == 3

--- a/app/views/rapidfire/answers/_date.html.erb
+++ b/app/views/rapidfire/answers/_date.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "rapidfire/answers/errors", locals: {answer: answer} %>
 <div class="form-group">
 <%= f.label :answer_text, answer.question.question_text %>
-<%= f.text_field :answer_text %>
+<%= f.date_field :answer_text %>
 </div>

--- a/db/migrate/20180605142534_make_survey_polymorphic.rb
+++ b/db/migrate/20180605142534_make_survey_polymorphic.rb
@@ -1,0 +1,14 @@
+if Rails::VERSION::MAJOR == 5
+  version = [Rails::VERSION::MAJOR, Rails::VERSION::MINOR].join('.').to_f
+  base = ActiveRecord::Migration[version]
+else
+  base = ActiveRecord::Migration
+end
+
+class MakeSurveyPolymorphic < base
+  def change
+    change_table :rapidfire_surveys do |t|
+      t.references :surveyable, polymorphic: true, index: true
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_05_143543) do
+ActiveRecord::Schema.define(version: 2018_06_05_142534) do
 
   create_table "rapidfire_answers", force: :cascade do |t|
     t.integer "attempt_id"
@@ -54,9 +54,7 @@ ActiveRecord::Schema.define(version: 2018_06_05_143543) do
     t.datetime "updated_at", null: false
     t.string "surveyable_type"
     t.integer "surveyable_id"
-    t.integer "user_id"
     t.index ["surveyable_type", "surveyable_id"], name: "index_rapidfire_surveys_on_surveyable_type_and_surveyable_id"
-    t.index ["user_id"], name: "index_rapidfire_surveys_on_user_id"
   end
 
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,14 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130502195504) do
-
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+ActiveRecord::Schema.define(version: 2018_06_05_143543) do
 
   create_table "rapidfire_answers", force: :cascade do |t|
-    t.bigint "attempt_id"
-    t.bigint "question_id"
+    t.integer "attempt_id"
+    t.integer "question_id"
     t.text "answer_text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -26,17 +23,18 @@ ActiveRecord::Schema.define(version: 20130502195504) do
   end
 
   create_table "rapidfire_attempts", force: :cascade do |t|
-    t.bigint "survey_id"
+    t.integer "survey_id"
     t.string "user_type"
-    t.bigint "user_id"
+    t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["survey_id"], name: "index_rapidfire_attempts_on_survey_id"
+    t.index ["user_id", "user_type"], name: "index_rapidfire_attempts_on_user_id_and_user_type"
     t.index ["user_type", "user_id"], name: "index_rapidfire_attempts_on_user_type_and_user_id"
   end
 
   create_table "rapidfire_questions", force: :cascade do |t|
-    t.bigint "survey_id"
+    t.integer "survey_id"
     t.string "type"
     t.string "question_text"
     t.string "default_text"
@@ -54,6 +52,11 @@ ActiveRecord::Schema.define(version: 20130502195504) do
     t.text "introduction"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "surveyable_type"
+    t.integer "surveyable_id"
+    t.integer "user_id"
+    t.index ["surveyable_type", "surveyable_id"], name: "index_rapidfire_surveys_on_surveyable_type_and_surveyable_id"
+    t.index ["user_id"], name: "index_rapidfire_surveys_on_user_id"
   end
 
 end


### PR DESCRIPTION
Allows surveys to be created and answered via API.

I've deliberately gone with the style that was established by Codemancers, with the idea that we might be able to contribute this (or at least, parts of it) back to the project.

I've also made surveys polymorphic so that we can associate them with content models (i.e. a `Series` can now `has_many: :surveys`)

Things might change here a bit as we integrate the surveys into our app and tease out the use-cases, so I wouldn't consider this stable yet. But, with this merged, I can get surveys into Ratings.

![](https://media.giphy.com/media/3og0ItZDg5QDHSFDVu/giphy.gif)